### PR TITLE
Igniter Activation Logging

### DIFF
--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -63,7 +63,7 @@
 /obj/machinery/sparker/power_change()
 	..()
 	if ( !(stat & NOPOWER) && disable == 0 )
-		
+
 		icon_state = "[base_state]"
 //		src.sd_SetLuminosity(2)
 	else
@@ -101,6 +101,7 @@
 
 
 	flick("[base_state]-spark", src)
+	log_game("Igniter activated by [usr.ckey]([usr]) in ([x],[y],[z])")
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(2, 1, src)
 	s.start()


### PR DESCRIPTION
When a player activates an igniter it gets logged. This is to help stop users from griefing with toxins; alerting admins when someone activates an igniter.