### PR TITLE
Plastic flaps fix

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -81,7 +81,7 @@
 /obj/structure/flora/pottedplant/MouseDrop(atom/over_object)
 	if (istype(over_object, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = over_object
-		if (H==usr && !H.restrained() && !H.stat && in_range(src, over_object))
+		if (H==usr && !H.restrained() && !H.stat && in_range(src, over_object) && !src.anchored)
 			var/obj/item/weapon/pottedplant/S = new/obj/item/weapon/pottedplant()
 			S.icon_state = src.icon_state
 			src.loc = S


### PR DESCRIPTION
Fixes cargo techs being able to steal plastic flaps since they're really potted plants! Tested and working, however varediting anchored to 0 didn't work. Other potted plants work just fine with this change however. Could be that I have no idea how to properly varedit though. (Sidenote, first time editing and also I have no idea why it inserted a line at the end and can't seem to prevent it)