### PR TITLE
Fixes the custom loadout spawning twice

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -401,16 +401,6 @@ var/global/datum/controller/occupations/job_master
 							continue
 
 						if(G.slot && !(G.slot in custom_equip_slots))
-							// This is a miserable way to fix the loadout overwrite bug, but the alternative requires
-							// adding an arg to a bunch of different procs. Will look into it after this merge. ~ Z
-							if(G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
-								custom_equip_leftovers += thing
-							else if(H.equip_to_slot_or_del(new G.path(H), G.slot))
-								H << "\blue Equipping you with [thing]!"
-								custom_equip_slots.Add(G.slot)
-							else
-								custom_equip_leftovers.Add(thing)
-						else
 							spawn_in_storage += thing
 			//Equip job items.
 			if(istype(job,/datum/job/deptguard))
@@ -437,15 +427,9 @@ var/global/datum/controller/occupations/job_master
 				if(G.slot in custom_equip_slots)
 					spawn_in_storage += thing
 				else
-					if(H.equip_to_slot_or_del(new G.path(H), G.slot))
-						H << "\blue Equipping you with [thing]!"
-						custom_equip_slots.Add(G.slot)
-					else
-						spawn_in_storage += thing
-		else
-			H << "Your job is [rank] and the game just can't handle it! Please report this bug to an administrator."
+					H << "Your job is [rank] and the game just can't handle it! Please report this bug to an administrator."
 
-		H.job = rank
+				H.job = rank
 
 		if(!joined_late)
 			var/obj/S = null


### PR DESCRIPTION
Totally didn't delete the code and stuff until it worked.
But it works. Only downside is the equipment goes into storage automatically, which in my opinion is better than getting it twice.